### PR TITLE
Add table pagination and search

### DIFF
--- a/organize_web/static/style.css
+++ b/organize_web/static/style.css
@@ -88,3 +88,13 @@ th {
   from { opacity: 0; transform: translateY(-5px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+.pagination {
+  display: flex;
+  align-items: center;
+  margin-top: 5px;
+}
+
+.search-input {
+  margin-top: 5px;
+}

--- a/organize_web/templates/index.html
+++ b/organize_web/templates/index.html
@@ -25,12 +25,18 @@
         <input id="anchor-values" placeholder="Values comma separated" />
         <button id="add-anchor-btn" onclick="addAnchor()">Add Anchor</button>
       </div>
+      <input id="anchor-search" class="search-input" placeholder="Search" oninput="updateAnchorList()" />
       <table id="anchor-table">
         <thead>
-          <tr><th>Key</th><th>Anchor</th><th>Values</th><th>Edit</th><th>Del</th></tr>
+          <tr><th>Key</th><th>Anchor</th><th>Values</th><th>Move</th><th>Edit</th><th>Del</th></tr>
         </thead>
         <tbody></tbody>
       </table>
+      <div class="pagination">
+        <button onclick="prevAnchorPage()">Prev</button>
+        <span id="anchor-page-info">1/1</span>
+        <button onclick="nextAnchorPage()">Next</button>
+      </div>
     </section>
 
     <section>
@@ -41,12 +47,18 @@
         <input id="kw-values" placeholder="Keywords comma separated" />
         <button id="add-kw-btn" onclick="addKeywordAnchor()">Add Keyword Anchor</button>
       </div>
+      <input id="kw-search" class="search-input" placeholder="Search" oninput="updateKeywordAnchorList()" />
       <table id="kw-anchor-table">
         <thead>
-          <tr><th>Key</th><th>Anchor</th><th>Values</th><th>Edit</th><th>Del</th></tr>
+          <tr><th>Key</th><th>Anchor</th><th>Values</th><th>Move</th><th>Edit</th><th>Del</th></tr>
         </thead>
         <tbody></tbody>
       </table>
+      <div class="pagination">
+        <button onclick="prevKwPage()">Prev</button>
+        <span id="kw-page-info">1/1</span>
+        <button onclick="nextKwPage()">Next</button>
+      </div>
     </section>
 
     <section>
@@ -64,14 +76,20 @@
         <input id="rule-move" placeholder="Move path" />
         <button id="add-rule-btn" onclick="addRule()">Add Rule</button>
       </div>
+      <input id="rule-search" class="search-input" placeholder="Search" oninput="updateRuleList()" />
       <table id="rule-table">
         <thead>
           <tr>
-            <th>Name</th><th>Location</th><th>Targets</th><th>Sub</th><th>Filter</th><th>Move</th><th>Edit</th><th>Del</th>
+            <th>Name</th><th>Location</th><th>Targets</th><th>Sub</th><th>Filter</th><th>Move Path</th><th>Order</th><th>Edit</th><th>Del</th>
           </tr>
         </thead>
         <tbody></tbody>
       </table>
+      <div class="pagination">
+        <button onclick="prevRulePage()">Prev</button>
+        <span id="rule-page-info">1/1</span>
+        <button onclick="nextRulePage()">Next</button>
+      </div>
     </section>
 
     <button onclick="downloadYaml()">Download YAML</button>


### PR DESCRIPTION
## Summary
- support pagination and search for anchors, keyword anchors and rules
- allow moving rows up/down for order control
- expose controls in the UI and style them

## Testing
- `python -m py_compile organize_web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6850f4e798ec832082f2d2cc8e129cc9